### PR TITLE
Ignore flag

### DIFF
--- a/resources/migrations/20210805091954-add-ignored-flag.down.sql
+++ b/resources/migrations/20210805091954-add-ignored-flag.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dictionary_unknownword
+DROP COLUMN isIgnored;

--- a/resources/migrations/20210805091954-add-ignored-flag.up.sql
+++ b/resources/migrations/20210805091954-add-ignored-flag.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dictionary_unknownword
+ADD COLUMN isIgnored BOOLEAN NOT NULL DEFAULT FALSE AFTER isLocal;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -184,6 +184,16 @@ ON u.untranslated = l.untranslated AND u.type = l.type AND u.document_id = l.doc
 WHERE u.untranslated IS NULL
 AND l.document_id = :document-id
 
+-- :name ignore-unknown-word :! :n
+-- :doc mark an unknown word given by `:untranslated`, `:type`, `:homograph-disambiguation` and `:document-id` as ingnored. This will change the order in which unknown words are returned in `get-all-unknown-words`
+
+UPDATE dictionary_unknownword
+SET isIgnored = TRUE
+WHERE untranslated = :untranslated
+AND type = :type
+AND homograph_disambiguation = :homograph-disambiguation
+AND document_id = :document-id
+
 -- :name get-all-unknown-words :? :*
 -- :doc given a `document-id` and a `:grade` retrieve all unknown words for it. If `:grade` is 0 then return words for both grade 1 and 2. Otherwise just return the unknown words for the given grade.This assumes that the new words contained in this document have been inserted into the `dictionary_unknownword` table.
 -- NOTE: This query assumes that there are only records for the current document-id in the dictionary_unknownword table.

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -262,7 +262,7 @@ WHERE unknown.type = 5
 AND g.untranslated IS NULL
 AND (((:grade IN (0,2)) AND l.contracted IS NULL) OR ((:grade IN (0,1)) AND l.uncontracted IS NULL))
 )
-ORDER BY untranslated
+ORDER BY isIgnored, untranslated
 LIMIT :limit OFFSET :offset
 
 -----------------------

--- a/src/clj/daisyproducer2/routes/services.clj
+++ b/src/clj/daisyproducer2/routes/services.clj
@@ -188,11 +188,13 @@
       :put {:summary "Update or create a local word for a given document"
             :middleware [wrap-restricted]
             :swagger {:security [{:apiAuth []}]}
-            :parameters {:body {:untranslated string? :type int?
+            :parameters {:body {:untranslated string?
+                                :type int?
                                 (spec/opt :uncontracted) ::braille
                                 (spec/opt :contracted) ::braille
                                 :homograph-disambiguation string?
-                                :document-id int? :islocal boolean?
+                                :document-id int?
+                                :islocal boolean?
                                 :hyphenated (spec/maybe ::hyphenation)
                                 :spelling ::spelling}}
             :handler (fn [{{word :body} :parameters}]
@@ -202,7 +204,8 @@
       :delete {:summary "Delete a local word for a given document"
                :middleware [wrap-restricted]
                :swagger {:security [{:apiAuth []}]}
-               :parameters {:body {:untranslated string? :type int?
+               :parameters {:body {:untranslated string?
+                                   :type int?
                                    (spec/opt :uncontracted) ::braille
                                    (spec/opt :contracted) ::braille
                                    :homograph-disambiguation string?

--- a/src/clj/daisyproducer2/routes/services.clj
+++ b/src/clj/daisyproducer2/routes/services.clj
@@ -227,7 +227,22 @@
                              :or {limit default-limit offset 0}} :query} :parameters}]
                        (let [version (docs/get-latest-version id)
                              unknown (unknown/get-words version id grade limit offset)]
-                         (ok unknown)))}}]
+                         (ok unknown)))}
+
+      :put {:summary "Ignore an unknown word for a given document"
+            :middleware [wrap-restricted]
+            :swagger {:security [{:apiAuth []}]}
+            :parameters {:body {:untranslated string?
+                                :type int?
+                                (spec/opt :uncontracted) ::braille
+                                (spec/opt :contracted) ::braille
+                                :homograph-disambiguation string?
+                                :document-id int?
+                                :hyphenated (spec/maybe ::hyphenation)
+                                :spelling ::spelling}}
+            :handler (fn [{{word :body} :parameters}]
+                       (unknown/ignore-word word)
+                       (no-content))}}]
 
     ["/versions"
      {:swagger {:tags ["Versions"]}}

--- a/src/clj/daisyproducer2/words/unknown.clj
+++ b/src/clj/daisyproducer2/words/unknown.clj
@@ -150,4 +150,12 @@
          (map words/complement-ellipsis-braille)
          (map words/complement-hyphenation))))))
 
+(defn ignore-word
+  "Mark an unknown `word` as \"ignored\". Returns the number of
+  updates."
+  [word]
+  (log/debug "Update unknown word" word)
+  (db/ignore-unknown-word word))
+
 (prometheus/instrument! metrics/registry #'get-words)
+(prometheus/instrument! metrics/registry #'ignore-word)


### PR DESCRIPTION
Add an `isIgnored` flag to the `dictionary_unknownword` table. The query to fetch the unknown words then orders by this flag and hence shows the ignored words last. Everything basically works (db model, queries, Clojure backend code, API end point and Clojurescript UI).

However there is a problem because while you can mark an unknown word as ignored this fact is _ignored_ because each request for unknown words currently wipes the `dictionary_unknownword` table clean and hence drops any information about ignored words.

To fix this we would probably have to update the `dictionary_unknownword` only when uploading a new version of a document and enhance the query to get all unknown words to only join with the unknown words for the given `document_id`.

TBH I'm not quite sure anymore what the motivation was behind the decision to wipe the `dictionary_unknownword` table for each request.